### PR TITLE
fastify empty post body causes the fst_err_ctp_empty_json_body

### DIFF
--- a/src/Request.ts
+++ b/src/Request.ts
@@ -63,6 +63,9 @@ export default class Request {
                 queryStringParams.data = data
                 queryStringParams.__isbase64 = true
             }
+            if (params.method === 'post' && !params.data){
+                params.data = {}
+            }
 
             return await this.axiosInstance!({ url: this.buildUrl(projectId, path), ...params, params: queryStringParams })
         } catch (error: any) {


### PR DESCRIPTION
fastify empty post body causes the fst_err_ctp_empty_json_body 

https://fastify.dev/docs/latest/Reference/Errors/#fst_err_ctp_empty_json_bodyhttps://fastify.dev/docs/latest/Reference/Errors/#fst_err_ctp_empty_json_body